### PR TITLE
add markdown support from ikatyang's

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 	path = sitters/tree-sitter-vim
 	url = https://github.com/neovim/tree-sitter-vim.git
 	shallow = true
+[submodule "sitters/tree-sitter-markdown"]
+	path = sitters/tree-sitter-markdown
+	url = https://github.com/ikatyang/tree-sitter-markdown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ default = [
     "javascript",
     "json",
     "lua",
+    "markdown",
     "python",
     "rust",
     "toml",
@@ -55,6 +56,7 @@ java = []
 javascript = []
 json = []
 lua = []
+markdown = []
 python = []
 rust = []
 toml = []

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Currently includes the following parsers:
 * JavaScript
 * Json
 * Lua
+* Markdown
 * Python
 * Rust
 * Toml

--- a/examples/highlighter.rs
+++ b/examples/highlighter.rs
@@ -73,6 +73,7 @@ lazy_static! {
             ("haskell", pepegsitter::haskell::highlight()),
             ("d", pepegsitter::d::highlight()),
             ("java", pepegsitter::java::highlight()),
+            ("markdown", pepegsitter::markdown::highlight()),
         ]
         .map(|(key, mut val)| {
             val.configure(HIGHLIGHT_NAMES);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pepegsit!(java, "java", "/lang_java.rs");
 pepegsit!(javascript, "javascript", "/lang_javascript.rs");
 pepegsit!(json, "json", "/lang_json.rs");
 pepegsit!(lua, "lua", "/lang_lua.rs");
+pepegsit!(markdown, "markdown", "/lang_markdown.rs");
 pepegsit!(python, "python", "/lang_python.rs");
 pepegsit!(rust, "rust", "/lang_rust.rs");
 pepegsit!(toml, "toml", "/lang_toml.rs");


### PR DESCRIPTION
[ikatyang's markdown treesitter parser](https://github.com/ikatyang/tree-sitter-markdown) works out of the box and adding it to Pepegsitter was a breeze. I also tested highlighting and it works fine. Besides Pepegsitter already uses ikatyang's toml parser. You might want to merge this instead of #2.